### PR TITLE
Fix FileNotFoundError when closing Anki after having uninstalled the add-on

### DIFF
--- a/chinese/config.py
+++ b/chinese/config.py
@@ -15,7 +15,10 @@ class ConfigManager:
         addHook('unloadProfile', self.save)
 
     def save(self):
-        mw.addonManager.writeConfig(__name__, self.options)
+        try:
+            mw.addonManager.writeConfig(__name__, self.options)
+        except FileNotFoundError as e:
+            print(e)
 
     def set_option(self, name, value):
         self.options[name] = value


### PR DESCRIPTION
First of all I would just like to say that I really appreciate all the work you've put into your add-ons over recent months. It's awesome to see the Anki 2.1 add-on ecosystem grow by each day.

This PR addresses a small error that I ran into while testing this add-on out: When closing Anki after uninstalling Chinese Support I would get a FileNotFoundError, which would result in a loop that would prevent me from closing the window.

This commit simply tries to handle instances like that more gracefully by catching the error and printing it to stdout instead of raising an error dialog.

P.S.: It could be argued that the Anki's add-on manager should take care of situations like this, but to be fair, it's really hard to trigger this error through regular interactions with the UI. (E.g.: a user would have to open the add-ons dialog, open the config dialog, manually delete the add-on in the background, and then close the config window again). Not sure how @dae sees this, so I decided to address the error on this level for now.