### PR TITLE
Improved character selection

### DIFF
--- a/chinese/dictdb.py
+++ b/chinese/dictdb.py
@@ -77,21 +77,27 @@ class DictDB:
         except:
             return None
 
-    def _get_word_pinyin(self, w, taiwan=False):
+    def _get_word_pinyin(self, w, taiwan=False, ignoreVariants=True):
         """Returns the pinyin transcription of a word, from CEDICT.
         If it's not in the dictionary, returns None.
         If there are multiple possibilities, returns one at random.
 
         if taiwan==True then prefer Taiwan variant
         """
+        selectStatement = "select pinyin, pinyin_taiwan from cidian where (traditional=? or simplified=?) "
+        if ignoreVariants:
+            selectStatement += "and (english not like '%variant%' and german not like '%variante%' and french not " \
+                               "like '%variante%' and spanish not like '%variante%'); "
 
-        self.c.execute("select pinyin, pinyin_taiwan from cidian where traditional=? or simplified=?;", (w, w))
+        self.c.execute(selectStatement, (w, w))
         try:
             pinyin, taiwan_pinyin = self.c.fetchone()
             if taiwan and taiwan_pinyin is not None:
                 return taiwan_pinyin
-            else:
+            elif pinyin is not None:
                 return pinyin
+            elif ignoreVariants:
+                return _get_word_pinyin(self, w, taiwan, False)
         except:
             #Not in dictionary
             return None

--- a/chinese/dictdb.py
+++ b/chinese/dictdb.py
@@ -86,8 +86,10 @@ class DictDB:
         """
         selectStatement = "select pinyin, pinyin_taiwan from cidian where (traditional=? or simplified=?) "
         if ignoreVariants:
-            selectStatement += "and (english not like '%variant%' and german not like '%variante%' and french not " \
-                               "like '%variante%' and spanish not like '%variante%'); "
+            selectStatement += "and ((english not like '%variant%' or english is null) " \
+                               "and (german not like '%variante%' or german is null) " \
+                               "and (french not like '%variante%' or french is null) " \
+                               "and (spanish not like '%variante%' or spanish is null)); "
 
         self.c.execute(selectStatement, (w, w))
         try:


### PR DESCRIPTION
When pulling from CEDICT to retrieve the pinyin it will now by default avoid using variants to determine the pinyin.

It will first search for the given character(s) ignoring characters that have the word 'variant' in the English definition (the other languages will ignore their translated version of variant). If none are found, it will re-run itself allowing all variants.

The SQL query shouldn't add significant overhead to the results. Searching will occur on the index first and then execute the like searches, since there are only a few variants per character this should be ok.