### PR TITLE
Fix search for multiple character words like 中国

### DIFF
--- a/chinese/transcribe.py
+++ b/chinese/transcribe.py
@@ -67,6 +67,12 @@ def transcribe(words, transcription=None, only_one=True):
     If no transcription is specified, use the transcription set in the menu.
     """
 
+    # if words is not a list, but a string like "中国"
+    # filter down below would break the string up into a list of two characters
+    # but this would break searching for words in the dictionary
+    if not isinstance(words, (list,)):
+        words = [words]
+
     words = list(filter(has_hanzi, words))
     transcribed = []
 

--- a/tests/test_behavior.py
+++ b/tests/test_behavior.py
@@ -17,7 +17,7 @@
 
 from unittest.mock import patch
 
-from chinese.behavior import fill_all_definitions
+from chinese.behavior import fill_all_definitions, update_Pinyin_fields
 from tests import ChineseTests
 
 
@@ -71,3 +71,26 @@ class FillAllDefinitionsTests(ChineseTests):
             self.assertEqual(fill_all_definitions(hanzi, note), 1)
             self.assertEqual(note['Meaning'], ' \tlibrary\n<br>')
             self.assertEqual(note['Classifier'], classifier)
+
+class UpdatePinyinFieldsTest(ChineseTests):
+    config = {
+        'dictionary': 'en',
+        'fields': {
+            'pinyin': ["Pinyin"]
+        }
+    }
+
+    def test_twocharacterword(self):
+        with patch('chinese.behavior.config', self.config):
+            hanzi = '中国'
+            note = {
+                'Pinyin': '',
+            }
+            # mind the spaces here
+            # if there are spaces between the spans and zhongguo in the comment,
+            # then transcribe was treating 中 and 国 as two separate words, what we do not want
+            pinyin = (
+                '<span class="tone1">zhōng</span><span class="tone2">guó</span><!--zhongguo-->'
+            )
+            self.assertEqual(update_Pinyin_fields(hanzi, note), 1)
+            self.assertEqual(note['Pinyin'], pinyin)

--- a/tests/test_transcribe.py
+++ b/tests/test_transcribe.py
@@ -93,6 +93,10 @@ class TranscribeTests(ChineseTests):
     def test_bopomofo(self):
         self.assertEqual(transcribe(['你'], 'Bopomofo'), ['ㄋㄧˇ'])
 
+    def test_multiple_words_single(self):
+        self.assertEqual(
+            transcribe('中国', 'Pinyin'), ['zhōng guó'])
+
 
 class ReplaceToneMarksTests(ChineseTests):
     def test_split_words(self):


### PR DESCRIPTION
On my system the plug-in finds the Pinyin for 中国 to be zhòng guó .
This is because it searches for 中 and 国 as two separate characters instead as a single word.

This patch fixes that behavior and adds regression tests.