### PR TITLE
Fix UnicodeDecodeError emitted when logging savefile in gTTS

### DIFF
--- a/chinese/lib/gtts/tts.py
+++ b/chinese/lib/gtts/tts.py
@@ -245,7 +245,7 @@ class gTTS:
         """
         with open(savefile, 'wb') as f:
             self.write_to_fp(f)
-            log.debug("Saved to %s", savefile)
+            log.debug("Saved to %s", str(savefile))
 
 
 class gTTSError(Exception):


### PR DESCRIPTION
Fixes #20 which is still happening for me on v100.