### PR TITLE
fix: Add in 'from anki.lang import _'

### DIFF
--- a/chinese/graph.py
+++ b/chinese/graph.py
@@ -24,6 +24,8 @@ selection (bottom of the window).
 import re
 import time
 
+from anki.lang import _
+
 now = time.mktime(time.localtime())
 
 

--- a/chinese/main.py
+++ b/chinese/main.py
@@ -16,6 +16,7 @@
 # Chinese Support Redux.  If not, see <https://www.gnu.org/licenses/>.
 
 from anki.hooks import addHook, wrap
+from anki.lang import _
 from anki.stats import CollectionStats
 from anki.stdmodels import models
 from aqt import mw


### PR DESCRIPTION
Suppresses ``accessing _ without importing from anki.lang will break in the future`` warning (at least when clicking on Anki "Stats").

I'm not sure if more of these import statements are necessary in other files to suppress this particular warning for all possible Chinese Support Redux features but this suppresses the warning if all you do is click on Anki "Stats".