### PR TITLE
Remove absent 'transcription' config field key

### DIFF
--- a/chinese/fill.py
+++ b/chinese/fill.py
@@ -144,7 +144,7 @@ def bulk_fill_transcript():
     )
 
     fields = config.get_fields(
-        ['transcription', 'pinyin', 'pinyinTaiwan', 'cantonese', 'bopomofo']
+        ['pinyin', 'pinyinTaiwan', 'cantonese', 'bopomofo']
     )
 
     if not askUser(prompt):


### PR DESCRIPTION
Prevents a KeyError from being thrown in `fill_bulk_transcript`.

Fixes #103 