### PR TITLE
Fix `has_any_field` and `has_field`

### DIFF
--- a/chinese/util.py
+++ b/chinese/util.py
@@ -23,6 +23,10 @@ from .consts import CLOZE_REGEX
 
 
 def has_field(fields, note):
+    if isinstance(fields, (str, bytes)):
+        raise ValueError(
+                "fields is string-like, should be list-like: {}".format(
+                    fields))
     for k in note:
         for f in fields:
             if str(f.lower()) == str(k.lower()):
@@ -32,7 +36,7 @@ def has_field(fields, note):
 
 def has_any_field(note, fields):
     for f in fields:
-        if has_field(f, note):
+        if has_field([f], note):
             return True
     return False
 


### PR DESCRIPTION
`has_field` expects a list of field names, but `has_any_field` iterates
over a list of field names and passes them to `has_field`, which causes
`has_any_field` to iterate over characters in a string instead of
strings in a list. Fix `has_any_field` to always pass lists to
`has_field`, and add a precondition check to `has_field` to catch this
issue in the future.