### PR TITLE
Fix for issue #134

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 chinese/config_saved.json
 chinese/meta.json
 Pipfile.lock
+.vscode

--- a/chinese/database.py
+++ b/chinese/database.py
@@ -177,6 +177,8 @@ class Dictionary:
         self.c.execute('SELECT %s FROM hanzi WHERE cp = ?' % to_col[type_], c)
         try:
             (k,) = self.c.fetchone()
+            if k is not None:
+                k = k.split()[0] # When returning two transcriptions just take the first.
             return k
         except:
             return None


### PR DESCRIPTION
In the comment at #134  I expanded a bit on the problem.

![Screenshot from 2020-06-06 16-30-32](https://user-images.githubusercontent.com/9380980/83946779-31b4d100-a813-11ea-9ad1-d8b6f4c44a7a.png)

You can see that the word separation is wrong: 地问 (dewen) is written as one word. (or is it correct?)  
Maybe the separation has to be improved...