### PR TITLE
Remove 'DeprecationWarning: invalid escape sequence'

### DIFF
--- a/chinese/lib/jieba/__init__.py
+++ b/chinese/lib/jieba/__init__.py
@@ -34,19 +34,19 @@ DICT_WRITING = {}
 
 pool = None
 
-re_userdict = re.compile('^(.+?)( [0-9]+)?( [a-z]+)?$', re.U)
+re_userdict = re.compile(r'^(.+?)( [0-9]+)?( [a-z]+)?$', re.U)
 
-re_eng = re.compile('[a-zA-Z0-9]', re.U)
+re_eng = re.compile(r'[a-zA-Z0-9]', re.U)
 
 # \u4E00-\u9FD5a-zA-Z0-9+#&\._ : All non-space characters. Will be handled with re_han
 # \r\n|\s : whitespace characters. Will not be handled.
 # re_han_default = re.compile("([\u4E00-\u9FD5a-zA-Z0-9+#&\._%]+)", re.U)
 # Adding "-" symbol in re_han_default
-re_han_default = re.compile("([\u4E00-\u9FD5a-zA-Z0-9+#&\._%\-]+)", re.U)
+re_han_default = re.compile(r'([\u4E00-\u9FD5a-zA-Z0-9+#&\._%\-]+)', re.U)
 
-re_skip_default = re.compile("(\r\n|\s)", re.U)
-re_han_cut_all = re.compile("([\u4E00-\u9FD5]+)", re.U)
-re_skip_cut_all = re.compile("[^a-zA-Z0-9+#\n]", re.U)
+re_skip_default = re.compile(r'(\r\n|\s)', re.U)
+re_han_cut_all = re.compile(r'([\u4E00-\u9FD5]+)', re.U)
+re_skip_cut_all = re.compile(r'[^a-zA-Z0-9+#\n]', re.U)
 
 def setLogLevel(log_level):
     global logger

--- a/chinese/lib/jieba/finalseg/__init__.py
+++ b/chinese/lib/jieba/finalseg/__init__.py
@@ -74,8 +74,8 @@ def __cut(sentence):
     if nexti < len(sentence):
         yield sentence[nexti:]
 
-re_han = re.compile("([\u4E00-\u9FD5]+)")
-re_skip = re.compile("([a-zA-Z0-9]+(?:\.\d+)?%?)")
+re_han = re.compile(r'([\u4E00-\u9FD5]+)')
+re_skip = re.compile(r'([a-zA-Z0-9]+(?:\.\d+)?%?)')
 
 
 def add_force_split(word):


### PR DESCRIPTION
This is a minimal change to make `make test` go through all green without any yellow warnings 😃.
The rest of my commit message:

> Change the regex patterns to use raw string instead
to prevent misinterpretation of string literals as
Unicode strings.
>
> Make 'make test' show no warnings on execution.