### PR TITLE
Bugfix: Allow simultaneously adding cards and browsing cards

### DIFF
--- a/chinese/edit.py
+++ b/chinese/edit.py
@@ -28,14 +28,15 @@ class EditManager:
         gui_hooks.editor_did_init_buttons.append(self.setupButton)
         gui_hooks.editor_did_load_note.append(self.updateButton)
         gui_hooks.editor_did_unfocus_field.append(self.onFocusLost)
+        self.editors = []
 
     def setupButton(self, buttons, editor):
-        self.editor = editor
+        self.editors.append(editor)
         self.buttonOn = False
-        editor._links['chineseSupport'] = self.onToggle
 
-        button = editor._addButton(
+        button = editor.addButton(
             icon=None,
+            func=self.onToggle,
             cmd='chineseSupport',
             tip='Chinese Support',
             label='<b>汉字</b>',
@@ -63,6 +64,10 @@ class EditManager:
             editor.web.eval('toggleEditorButton(chineseSupport);')
             self.buttonOn = not self.buttonOn
 
+    def _refreshAllEditors(self, focusTo):
+        for editor in self.editors:
+            editor.loadNote(focusTo=focusTo)
+
     def onFocusLost(self, _, note, index):
         if not self.buttonOn:
             return False
@@ -71,10 +76,8 @@ class EditManager:
         field = allFields[index]
 
         if update_fields(note, field, allFields):
-            if index == len(allFields) - 1:
-                self.editor.loadNote(focusTo=index)
-            else:
-                self.editor.loadNote(focusTo=index+1)
+            focusTo = (index + 1) % len(allFields)
+            self._refreshAllEditors(focusTo)
 
         return False
 

--- a/chinese/edit.py
+++ b/chinese/edit.py
@@ -17,8 +17,7 @@
 # You should have received a copy of the GNU General Public License along with
 # Chinese Support Redux.  If not, see <https://www.gnu.org/licenses/>.
 
-from anki.hooks import addHook
-from aqt import mw
+from aqt import mw, gui_hooks
 
 from .behavior import update_fields
 from .main import config
@@ -26,9 +25,9 @@ from .main import config
 
 class EditManager:
     def __init__(self):
-        addHook('setupEditorButtons', self.setupButton)
-        addHook('loadNote', self.updateButton)
-        addHook('editFocusLost', self.onFocusLost)
+        gui_hooks.editor_did_init_buttons.append(self.setupButton)
+        gui_hooks.editor_did_load_note.append(self.updateButton)
+        gui_hooks.editor_did_unfocus_field.append(self.onFocusLost)
 
     def setupButton(self, buttons, editor):
         self.editor = editor
@@ -43,7 +42,7 @@ class EditManager:
             id='chineseSupport',
             toggleable=True)
 
-        return buttons + [button]
+        buttons.append(button)
 
     def onToggle(self, editor):
         self.buttonOn = not self.buttonOn

--- a/chinese/main.py
+++ b/chinese/main.py
@@ -15,11 +15,10 @@
 # You should have received a copy of the GNU General Public License along with
 # Chinese Support Redux.  If not, see <https://www.gnu.org/licenses/>.
 
-from anki.hooks import addHook, wrap
-from anki.lang import _
+from anki.hooks import wrap
 from anki.stats import CollectionStats
 from anki.stdmodels import models
-from aqt import mw
+from aqt import mw, gui_hooks
 
 from .config import ConfigManager
 from .database import Dictionary
@@ -42,12 +41,12 @@ if config['firstRun']:
 def load():
     ruby.install()
     chinese.install()
-    addHook('profileLoaded', load_menu)
-    addHook('profileLoaded', add_models)
-    addHook('loadNote', append_tone_styling)
-    addHook('unloadProfile', config.save)
-    addHook('unloadProfile', dictionary.conn.close)
-    addHook('unloadProfile', unload_menu)
+    gui_hooks.profile_did_open.append(load_menu)
+    gui_hooks.profile_did_open.append(add_models)
+    gui_hooks.editor_did_load_note.append(append_tone_styling)
+    gui_hooks.profile_will_close.append(config.save)
+    gui_hooks.profile_will_close.append(dictionary.conn.close)
+    gui_hooks.profile_will_close.append(unload_menu)
     CollectionStats.todayStats = wrap(
         CollectionStats.todayStats, todayStats, 'around'
     )


### PR DESCRIPTION
Fixes a bug where simultaneous adding new cards and having the card browser open for editing stops the auto-fill feature from working correctly.

`edit.EditManager` wrongly assumes that there is only one `Editor` instance.  The window for adding cards and the browsing window each instantiate their own editor.

Other small changes include replacing some legacy GUI hooks, see
- https://addon-docs.ankiweb.net/#/hooks-and-filters?id=new-style-hooks
- https://github.com/ankitects/anki/blob/main/qt/tools/genhooks_gui.py
