### PR TITLE
Add frequency to bulk fill menu

### DIFF
--- a/chinese/behavior.py
+++ b/chinese/behavior.py
@@ -242,13 +242,16 @@ def fill_trad(hanzi, note):
         set_all(config['fields']['traditional'], note, to='')
 
 
-def fill_frequency(hanzi, note):
+def fill_frequency(hanzi, note) -> bool:
     if get_first(config['fields']['frequency'], note) == '':
         set_all(
             config['fields']['frequency'],
             note,
             to=get_frequency(get_simp(hanzi)),
         )
+        return True
+
+    return False
 
 
 def fill_ruby(hanzi, note, trans_group, ruby_group):

--- a/chinese/gui.py
+++ b/chinese/gui.py
@@ -30,6 +30,7 @@ from .fill import (
     bulk_fill_all,
     bulk_fill_classifiers,
     bulk_fill_defs,
+    bulk_fill_frequency,
     bulk_fill_hanzi,
     bulk_fill_silhouette,
     bulk_fill_sound,
@@ -83,6 +84,7 @@ def load_menu():
     add_menu_item('Chinese::Bulk Fill', _('Classifiers'), bulk_fill_classifiers)
     add_menu_item('Chinese::Bulk Fill', _('Sound'), bulk_fill_sound)
     add_menu_item('Chinese::Bulk Fill', _('Silhouette'), bulk_fill_silhouette)
+    add_menu_item("Chinese::Bulk Fill", _("Frequency"), bulk_fill_frequency)
     add_menu_item('Chinese::Bulk Fill', _('Usage'), bulk_fill_usage)
     add_menu_item('Chinese::Bulk Fill', _('All'), bulk_fill_all)
 


### PR DESCRIPTION
Frequency was not previously included in the bulk fill menu as a single
option, but this is useful for people who already have other more common
fields (e.g., pinyin and definition) and want to add frequency
information.

Closes #129