### PR TITLE
Add support for Pinyin with tone numbers instead of accents.

### DIFF
--- a/chinese/behavior.py
+++ b/chinese/behavior.py
@@ -28,6 +28,7 @@ from .transcribe import (
     sanitize_transcript,
     split_transcript,
     transcribe,
+    tone_marks_to_numbers,
 )
 from .translate import translate
 from .util import (
@@ -151,6 +152,12 @@ def fill_transcript(hanzi, note):
             n_filled += 1
         else:
             reformat_transcript(note, key, target)
+
+    if get_first(config['fields']['pinyinNum'], note) == '':
+        t = transcribe(separated, target, type_)
+        s = tone_marks_to_numbers(str.join(" ", t))
+        set_all(config['fields']['pinyinNum'], note, to=s)
+        n_filled += 1
 
     return n_filled
 

--- a/chinese/config.json
+++ b/chinese/config.json
@@ -41,6 +41,9 @@
             "大陸拼音",
             "拼音"
         ],
+        "pinyinNum": [
+            "PinyinNum"
+        ],
         "pinyinTaiwan": [
             "Pinyin (Taiwan)",
             "台湾拼音",

--- a/chinese/transcribe.py
+++ b/chinese/transcribe.py
@@ -238,6 +238,10 @@ def split_transcript(transcript, target, grouped=True):
 
     return list(filter(lambda s: s.strip(), separated))
 
+def tone_marks_to_numbers(s):
+    assert isinstance(s, str)
+    s2, *_ = replace_tone_marks([cleanup(s)])
+    return s2
 
 def tone_number(s):
     assert isinstance(s, str)


### PR DESCRIPTION
Implements https://github.com/luoliyan/chinese-support-redux/issues/218. Adds a separate field PinyinNum for pinyin with tone numbers. The implementation is a bit of a hack, but it works and shows how the feature could work.